### PR TITLE
Changed from zencoding-vim to emmet-vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -35,7 +35,7 @@ Bundle 'majutsushi/tagbar'
 " Code and files fuzzy finder
 Bundle 'kien/ctrlp.vim'
 " Zen coding
-Bundle 'mattn/zencoding-vim'
+Bundle 'mattn/emmet-vim'
 " Git integration
 Bundle 'motemen/git-vim'
 " Tab list panel


### PR DESCRIPTION
This repository (https://github.com/mattn/zencoding-vim) has moved to https://github.com/mattn/emmet-vim